### PR TITLE
v0.5.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
         "no-trailing-spaces": ["warn"],
         "no-throw-literal": "off",
         "no-useless-constructor": "off",
+        "no-constant-condition": "off",
         "quotes": ["warn", "single"],
         "semi": ["off"],
         "@typescript-eslint/typedef": [

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,9 @@ updates:
         patterns:
           - "@types/md5"
           - "md5"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # Enable version updates for pip
   - package-ecosystem: pip

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          days-before-issue-stale: 60
-          days-before-issue-close: 14
-          stale-issue-label: Stale
-          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          stale-issue-label: stale
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
           close-issue-reason: not_planned
-          days-before-pr-stale: 90
-          days-before-pr-close: 21
-          stale-pr-label: Stale
-          stale-pr-message: "This pull request is stale because it has been open for 90 days with no activity."
-          close-pr-message: "This pull request was closed because it has been inactive for 21 days since being marked as stale."
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          stale-pr-message: "This pull request is stale because it has been open for 60 days with no activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 14 days since being marked as stale."

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This plugin automatically discovers Apple TV devices in the local network and ex
         -   On debian-based distros: `sudo apt install python3-venv`
         -   Installation on other distros may vary
 -   Apple TV Models A1625, A1842, A2169, A2737, A2843 are supported (all 4K ones and the latest HD one)
--   The access of Speakers & TVs should by either set to "Everybody" or "Anybody On the Same Network" in the Home app
+-   The access of Speakers & TVs should be either set to "Everybody" or "Anybody On the Same Network" in the Home app
 -   Raspberry Pi 1, 2, 3 and Zero 1, 2 are not recommended for performance reasons. Recommended are 3B+, 4B, 5B.
 -   The homebridge instance and Apple TVs need to be on the same subnet.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This plugin automatically discovers Apple TV devices in the local network and ex
 -   Pairing process without the need to access the command line like with other plugins.
 -   Change the current App by selecting an input in HomeKit.
     -   The plugin is developed in a way that makes it possible to rename, hide or show inputs in HomeKit natively ... and safes it.
+    -   You can even define own inputs based on URIs in the configuration. For instance, you can create an input to open a certain Disney+ movie or show ... or pretty much anything you can think of. Take a look at the example `config.json` ;).
 -   The automation triggers that you are probably here for ...
     -   Since every Apple TV is exposed as a Set-Top Box, you can create a trigger on the power state to execute automations when turning on or off.
     -   For each media type (music, video, tv and unknown) the plugin will create a motion sensor (media types can be hidden or shown by changing the configuration).
@@ -110,6 +111,12 @@ To configure manually, add the following to the `platforms` section of Homebridg
         "turn_on",
         "top_menu",
         "up"
+    ],
+    "customInputURIs": [
+        "https://www.disneyplus.com/movies/rogue-one-a-star-wars-story/14CV6eSbygOA",
+        "https://www.netflix.com/watch/81260280",
+        "https://tv.apple.com/show/silo/umc.cmc.3yksgc857px0k0rqe5zd4jice",
+        "vlc://https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8"
     ],
     "avadaKedavraAppAmount": 15,
     "discover": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -89,6 +89,18 @@
                 "minimum": 5,
                 "maximum": 35
             },
+            "customInputURIs": {
+                "title": "Custom Input URIs",
+                "description": "Provide URIs for custom Inputs that open the URI on the Apple TV when selected",
+                "type": "array",
+                "default": [],
+                "required": true,
+                "items": {
+                    "type": "string",
+                    "title": "URI",
+                    "placeholder": "vlc://https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8"
+                }
+            },
             "discover": {
                 "title": "Discover",
                 "description": "Settings regarding the discovery of Apple TVs.",

--- a/config.schema.json
+++ b/config.schema.json
@@ -98,7 +98,7 @@
                 "items": {
                     "type": "string",
                     "title": "URI",
-                    "placeholder": "vlc://https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8"
+                    "placeholder": "https://www.disneyplus.com/movies/rogue-one-a-star-wars-story/14CV6eSbygOA"
                 }
             },
             "discover": {

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,4 @@
 {
-    "watch": ["src"],
     "ext": "ts",
     "ignore": [],
     "exec": "tsc && homebridge -I -D",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-appletv-enhanced",
-    "version": "0.5.0-1",
+    "version": "0.5.0-2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-appletv-enhanced",
-            "version": "0.5.0-1",
+            "version": "0.5.0-2",
             "funding": [
                 {
                     "type": "paypal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-appletv-enhanced",
-    "version": "0.5.0-2",
+    "version": "0.5.0-3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-appletv-enhanced",
-            "version": "0.5.0-2",
+            "version": "0.5.0-3",
             "funding": [
                 {
                     "type": "paypal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
             },
             "devDependencies": {
                 "@types/md5": "^2.3.5",
-                "@types/node": "^20.9.0",
+                "@types/node": "^18.18.9",
                 "@typescript-eslint/eslint-plugin": "^6.11.0",
                 "@typescript-eslint/parser": "^6.11.0",
                 "eslint": "^8.53.0",
@@ -619,9 +619,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.9.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-            "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+            "version": "18.18.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
+            "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-appletv-enhanced",
-    "version": "0.4.1",
+    "version": "0.5.0-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-appletv-enhanced",
-            "version": "0.4.1",
+            "version": "0.5.0-0",
             "funding": [
                 {
                     "type": "paypal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-appletv-enhanced",
-    "version": "0.5.0-0",
+    "version": "0.5.0-1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-appletv-enhanced",
-            "version": "0.5.0-0",
+            "version": "0.5.0-1",
             "funding": [
                 {
                     "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homebridge-appletv-enhanced",
     "displayName": "Apple TV Enhanced",
-    "version": "0.5.0-2",
+    "version": "0.5.0-3",
     "description": "Plugin that exposes the Apple TV to HomeKit with much richer features than the vanilla Apple TV implementation of HomeKit.",
     "main": "dist/index.js",
     "author": "Maximilian Leith",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "url": "http://github.com/maxileith/homebridge-appletv-enhanced/issues"
     },
     "devDependencies": {
-        "@types/node": "^20.9.0",
+        "@types/node": "^18.18.9",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
         "@typescript-eslint/parser": "^6.11.0",
         "eslint": "^8.53.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Maximilian Leith",
     "scripts": {
         "lint": "eslint src/**.ts --max-warnings=0",
-        "watch": "npm run build && npm link && nodemon",
+        "watch": "npm run build && npm link && nodemon --watch src --watch /var/lib/homebridge/config.json --watch ~/.homebridge/config.json",
         "build": "npm ci && rimraf -I ./dist && npm run lint && tsc && mkdir ./dist/html && cp ./src/html/*.html ./dist/html",
         "prepublishOnly": "npm run build",
         "postversion": "git push && git push --tags"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homebridge-appletv-enhanced",
     "displayName": "Apple TV Enhanced",
-    "version": "0.5.0-1",
+    "version": "0.5.0-2",
     "description": "Plugin that exposes the Apple TV to HomeKit with much richer features than the vanilla Apple TV implementation of HomeKit.",
     "main": "dist/index.js",
     "author": "Maximilian Leith",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homebridge-appletv-enhanced",
     "displayName": "Apple TV Enhanced",
-    "version": "0.5.0-0",
+    "version": "0.5.0-1",
     "description": "Plugin that exposes the Apple TV to HomeKit with much richer features than the vanilla Apple TV implementation of HomeKit.",
     "main": "dist/index.js",
     "author": "Maximilian Leith",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "keywords": [
         "homebridge-plugin",
         "appletv",
+        "apple tv",
         "apple",
         "tv",
         "homebridge",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homebridge-appletv-enhanced",
     "displayName": "Apple TV Enhanced",
-    "version": "0.4.1",
+    "version": "0.5.0-0",
     "description": "Plugin that exposes the Apple TV to HomeKit with much richer features than the vanilla Apple TV implementation of HomeKit.",
     "main": "dist/index.js",
     "author": "Maximilian Leith",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,8 @@ mutagen==1.47.0
 protobuf==4.25.0
 pyatv==0.14.4
 pycparser==2.21
-pydantic==2.5.0
-pydantic_core==2.14.1
+pydantic==2.5.1
+pydantic_core==2.14.3
 requests==2.31.0
 six==1.16.0
 srptools==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ tabulate==0.9.0
 typing_extensions==4.8.0
 urllib3==2.1.0
 yarl==1.9.2
-zeroconf==0.126.0
+zeroconf==0.127.0

--- a/src/CustomPyAtvInstance.ts
+++ b/src/CustomPyAtvInstance.ts
@@ -19,12 +19,13 @@ class CustomPyATVInstance extends nodePyatv.NodePyATVInstance {
     }
 
     public static async find(options?: nodePyatv.NodePyATVFindAndInstanceOptions): Promise<nodePyatv.NodePyATVDevice[]> {
-        return nodePyatv.NodePyATVInstance.find(this.extendOptions(options)).then(async (results) => {
-            for (const result of results) {
-                this.cachedDevices[result.id!] = result;
-            }
-            return results;
-        });
+        return nodePyatv.NodePyATVInstance.find(this.extendOptions(options))
+            .then(async (results) => {
+                for (const result of results) {
+                    this.cachedDevices[result.id!] = result;
+                }
+                return results;
+            });
     }
 
     public static deviceAdvanced(

--- a/src/PythonChecker.ts
+++ b/src/PythonChecker.ts
@@ -56,11 +56,10 @@ class PythonChecker {
     private async ensurePythonVersion(): Promise<void> {
         const version: string = await this.getSystemPythonVersion();
         if (SUPPORTED_PYTHON_VERSIONS.findIndex((e) => version.includes(e)) === -1) {
-            // eslint-disable-next-line no-constant-condition
             while (true) {
                 this.log.error(`${version} is installed. However, only Python \
 ${SUPPORTED_PYTHON_VERSIONS[0]} to ${SUPPORTED_PYTHON_VERSIONS[SUPPORTED_PYTHON_VERSIONS.length - 1]} is supported.`);
-                await delay(120000);
+                await delay(300000);
             }
         } else {
             this.log.info(`Python ${version} is installed and supported by the plugin.`);
@@ -105,12 +104,11 @@ Recreating the virtual environment now ...`);
     private async createVenv(): Promise<void> {
         const [stdout]: [string, string] = await this.runCommand('python3', ['-m', 'venv', this.venvPath, '--clear'], undefined, true);
         if (stdout.includes('not created successfully') || !this.isVenvCreated()) {
-            // eslint-disable-next-line no-constant-condition
             while (true) {
                 this.log.error('virtualenv python module is not installed. You need to install the \
 python package virtualenv either by using \'python3 -m pip install virutalenv\' or installing it via system packages. \
 On debian based distributions this is usally \'sudo apt install python3-venv\'');
-                await delay(60000);
+                await delay(300000);
             }
         } else if (stdout.trim() !== '') {
             this.log.warn(stdout);

--- a/src/RocketRemote.ts
+++ b/src/RocketRemote.ts
@@ -46,9 +46,9 @@ class RocketRemote {
 
     public sendCommand(cmd: RocketRemoteKey | string, hideLog: boolean = false): void {
         if (hideLog) {
-            this.log.debug(`pyatv>${cmd}`);
+            this.log.debug(cmd);
         } else {
-            this.log.info(`pyatv>${cmd}`);
+            this.log.info(cmd);
         }
         this.process.stdin.write(`${cmd}\n`);
         this.lastCommandSend = Date.now();

--- a/src/appleTVEnhancedAccessory.ts
+++ b/src/appleTVEnhancedAccessory.ts
@@ -254,15 +254,13 @@ export class AppleTVEnhancedAccessory {
             if (this.platform.config.mediaTypes !== undefined && !this.platform.config.mediaTypes.includes(mediaType)) {
                 continue;
             }
-            this.log.debug(`Adding media type ${mediaType} as a motion sensor.`);
+            const configuredName: string = this.getMediaConfigs()[mediaType] || capitalizeFirstLetter(mediaType);
+            this.log.debug(`Adding media type ${mediaType} as a motion sensor. (named: ${configuredName})`);
             const s: Service = this.accessory.getService(mediaType) ||
                 this.addServiceSave(this.platform.Service.MotionSensor, mediaType, mediaType)!
                     .setCharacteristic(this.platform.Characteristic.MotionDetected, false)
                     .setCharacteristic(this.platform.Characteristic.Name, capitalizeFirstLetter(mediaType))
-                    .setCharacteristic(
-                        this.platform.Characteristic.ConfiguredName,
-                        this.getMediaConfigs()[mediaType] || capitalizeFirstLetter(mediaType),
-                    );
+                    .setCharacteristic(this.platform.Characteristic.ConfiguredName, configuredName);
             s.getCharacteristic(this.platform.Characteristic.ConfiguredName)
                 .onSet(async (value: CharacteristicValue) => {
                     if (value === '') {
@@ -294,14 +292,12 @@ export class AppleTVEnhancedAccessory {
             if (this.platform.config.remoteKeysAsSwitch !== undefined && !this.platform.config.remoteKeysAsSwitch.includes(remoteKey)) {
                 continue;
             }
-            this.log.debug(`Adding remote key ${remoteKey} as a switch.`);
+            const configuredName: string = this.getRemoteKeyAsSwitchConfigs()[remoteKey] || snakeCaseToTitleCase(remoteKey);
+            this.log.debug(`Adding remote key ${remoteKey} as a switch. (named: ${configuredName})`);
             const s: Service = this.accessory.getService(remoteKey) ||
                 this.addServiceSave(this.platform.Service.Switch, remoteKey, remoteKey)!
                     .setCharacteristic(this.platform.Characteristic.Name, capitalizeFirstLetter(remoteKey))
-                    .setCharacteristic(
-                        this.platform.Characteristic.ConfiguredName,
-                        this.getRemoteKeyAsSwitchConfigs()[remoteKey] || snakeCaseToTitleCase(remoteKey),
-                    )
+                    .setCharacteristic(this.platform.Characteristic.ConfiguredName, configuredName)
                     .setCharacteristic(this.platform.Characteristic.On, false);
             s.getCharacteristic(this.platform.Characteristic.ConfiguredName)
                 .onSet(async (value: CharacteristicValue) => {
@@ -357,17 +353,15 @@ export class AppleTVEnhancedAccessory {
             if (this.platform.config.deviceStates !== undefined && !this.platform.config.deviceStates.includes(deviceState)) {
                 continue;
             }
-            this.log.debug(`Adding device state ${deviceState} as a motion sensor.`);
+            const configuredName: string = this.getDeviceStateConfigs()[deviceState] || capitalizeFirstLetter(deviceState);
+            this.log.debug(`Adding device state ${deviceState} as a motion sensor. (named: ${configuredName})`);
             const s: Service = this.accessory.getService(deviceState) ||
                 this.addServiceSave(this.platform.Service.MotionSensor, deviceState, deviceState)!
                     .setCharacteristic(this.platform.Characteristic.MotionDetected, false)
                     .setCharacteristic(this.platform.Characteristic.Name, capitalizeFirstLetter(deviceState))
-                    .setCharacteristic(
-                        this.platform.Characteristic.ConfiguredName,
-                        this.getDeviceStateConfigs()[deviceState] || capitalizeFirstLetter(deviceState),
-                    );
+                    .setCharacteristic(this.platform.Characteristic.ConfiguredName, configuredName);
             s.getCharacteristic(this.platform.Characteristic.ConfiguredName)
-                .onSet(async (value) => {
+                .onSet(async (value: CharacteristicValue) => {
                     if (value === '') {
                         return;
                     }
@@ -446,11 +440,12 @@ export class AppleTVEnhancedAccessory {
                 ? this.platform.Characteristic.CurrentVisibilityState.HIDDEN
                 : this.platform.Characteristic.CurrentVisibilityState.SHOWN;
 
-        this.log.debug('Adding Avada Kedavra as an input.');
+        const configuredName: string = this.getCommonConfig()['avadaKedavraName'] || 'Avada Kedavra';
+        this.log.debug(`Adding Avada Kedavra as an input. (named: ${configuredName})`);
 
         this.avadaKedavraService = this.accessory.getService('Avada Kedavra') ||
             this.addServiceSave(this.platform.Service.InputSource, 'Avada Kedavra', 'avadaKedavra')!
-                .setCharacteristic(this.platform.Characteristic.ConfiguredName, 'Avada Kedavra')
+                .setCharacteristic(this.platform.Characteristic.ConfiguredName, configuredName)
                 .setCharacteristic(this.platform.Characteristic.InputSourceType, this.platform.Characteristic.InputSourceType.OTHER)
                 .setCharacteristic(this.platform.Characteristic.IsConfigured, this.platform.Characteristic.IsConfigured.CONFIGURED)
                 .setCharacteristic(this.platform.Characteristic.Name, 'Avada Kedavra')
@@ -460,7 +455,7 @@ export class AppleTVEnhancedAccessory {
                 .setCharacteristic(this.platform.Characteristic.Identifier, AVADA_KEDAVRA_IDENTIFIER);
 
         this.avadaKedavraService.getCharacteristic(this.platform.Characteristic.TargetVisibilityState)
-            .onSet(async (value) => {
+            .onSet(async (value: CharacteristicValue) => {
                 const current: Nullable<CharacteristicValue> =
                     this.avadaKedavraService!.getCharacteristic(this.platform.Characteristic.TargetVisibilityState).value;
                 this.log.info(`Changing visibility state of Avada Kedavra from ${current} to ${value}.`);
@@ -491,7 +486,7 @@ export class AppleTVEnhancedAccessory {
 
         let addedApps: number = 0;
         apps.every((app) => {
-            this.log.debug(`Adding ${appConfigs[app.id].configuredName} (${app.id}) as an input.`);
+            this.log.debug(`Adding ${app.id} as an input. (named: ${appConfigs[app.id].configuredName})`);
             const s: Service | undefined =
                 this.accessory.getService(app.name) || this.addServiceSave(this.platform.Service.InputSource, app.name, app.id);
 
@@ -519,7 +514,7 @@ It might be a good idea to uninstall unused apps.`);
                 .setCharacteristic(this.platform.Characteristic.TargetVisibilityState, appConfigs[app.id].visibilityState)
                 .setCharacteristic(this.platform.Characteristic.Identifier, appConfigs[app.id].identifier);
             s.getCharacteristic(this.platform.Characteristic.ConfiguredName)
-                .onSet(async (value) => {
+                .onSet(async (value: CharacteristicValue) => {
                     if (value === '') {
                         return;
                     }
@@ -530,18 +525,21 @@ It might be a good idea to uninstall unused apps.`);
                     appConfigs[app.id].configuredName = value.toString();
                     this.setAppConfigs(appConfigs);
                 })
-                .onGet(async () => {
+                .onGet(async (): Promise<Nullable<CharacteristicValue>> => {
+                    if (this.offline) {
+                        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+                    }
                     return appConfigs[app.id].configuredName;
                 });
             s.getCharacteristic(this.platform.Characteristic.IsConfigured)
-                .onSet(async (value) => {
+                .onSet(async (value: CharacteristicValue) => {
                     this.log.info(`Changing is configured of ${appConfigs[app.id].configuredName} (${app.id}) \
 from ${appConfigs[app.id].isConfigured} to ${value}.`);
                     appConfigs[app.id].isConfigured = value as 0 | 1;
                     this.setAppConfigs(appConfigs);
                 });
             s.getCharacteristic(this.platform.Characteristic.TargetVisibilityState)
-                .onSet(async (value) => {
+                .onSet(async (value: CharacteristicValue) => {
                     this.log.info(`Changing visibility state of ${appConfigs[app.id].configuredName} (${app.id}) \
 from ${appConfigs[app.id].visibilityState} to ${value}.`);
                     appConfigs[app.id].visibilityState = value as 0 | 1;

--- a/src/appleTVEnhancedAccessory.ts
+++ b/src/appleTVEnhancedAccessory.ts
@@ -207,13 +207,13 @@ export class AppleTVEnhancedAccessory {
         };
 
         const powerStateListener = (e: Error | NodePyATVDeviceEvent): void => filterErrorHandler(e, this.handleActiveUpdate.bind(this));
-        // const appIdListener = (e: Error | NodePyATVDeviceEvent) => filterErrorHandler(e, this.handleInputUpdate.bind(this));
+        const appIdListener = (e: Error | NodePyATVDeviceEvent): void => filterErrorHandler(e, this.handleInputUpdate.bind(this));
         const deviceStateListener = (e: Error | NodePyATVDeviceEvent): void => filterErrorHandler(
             e, this.handleDeviceStateUpdate.bind(this));
         const mediaTypeListener = (e: Error | NodePyATVDeviceEvent): void => filterErrorHandler(e, this.handleMediaTypeUpdate.bind(this));
 
         this.device.on('update:powerState', powerStateListener);
-        // this.device.on('update:appId', appIdListener);
+        this.device.on('update:appId', appIdListener);
         this.device.on('update:deviceState', deviceStateListener);
         this.device.on('update:mediaType', mediaTypeListener);
 
@@ -223,7 +223,7 @@ export class AppleTVEnhancedAccessory {
             this.log.warn('Lost connection. Trying to reconnect ...');
 
             this.device.removeListener('update:powerState', powerStateListener);
-            // this.device.removeListener('update:appId', appIdListener);
+            this.device.removeListener('update:appId', appIdListener);
             this.device.removeListener('update:deviceState', deviceStateListener);
             this.device.removeListener('update:mediaType', mediaTypeListener);
 

--- a/src/appleTVEnhancedAccessory.ts
+++ b/src/appleTVEnhancedAccessory.ts
@@ -129,7 +129,7 @@ export class AppleTVEnhancedAccessory {
     }
 
     private async startUp(): Promise<void> {
-        this.accessory.category = this.platform.api.hap.Categories.TV_SET_TOP_BOX;
+        this.accessory.category = this.platform.api.hap.Categories.APPLE_TV;
 
         // set accessory information
         this.accessory.getService(this.platform.Service.AccessoryInformation)!

--- a/src/appleTVEnhancedAccessory.ts
+++ b/src/appleTVEnhancedAccessory.ts
@@ -454,6 +454,26 @@ export class AppleTVEnhancedAccessory {
                 .setCharacteristic(this.platform.Characteristic.TargetVisibilityState, visibilityState)
                 .setCharacteristic(this.platform.Characteristic.Identifier, AVADA_KEDAVRA_IDENTIFIER);
 
+        this.avadaKedavraService.getCharacteristic(this.platform.Characteristic.ConfiguredName)
+            .onSet(async (value: CharacteristicValue) => {
+                if (value === '') {
+                    return;
+                }
+                const oldValue: Nullable<CharacteristicValue> =
+                    this.avadaKedavraService!.getCharacteristic(this.platform.Characteristic.ConfiguredName).value;
+                if (oldValue === value) {
+                    return;
+                }
+                this.log.info(`Changing configured name of Avada Kedavra from ${oldValue} to ${value}.`);
+                this.setCommonConfig('avadaKedavraName', value.toString());
+            })
+            .onGet(async (): Promise<Nullable<CharacteristicValue>> => {
+                if (this.offline) {
+                    throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+                }
+                return this.avadaKedavraService!.getCharacteristic(this.platform.Characteristic.ConfiguredName).value;
+            });
+
         this.avadaKedavraService.getCharacteristic(this.platform.Characteristic.TargetVisibilityState)
             .onSet(async (value: CharacteristicValue) => {
                 const current: Nullable<CharacteristicValue> =

--- a/src/appleTVEnhancedPlatform.ts
+++ b/src/appleTVEnhancedPlatform.ts
@@ -13,8 +13,6 @@ export class AppleTVEnhancedPlatform implements DynamicPlatformPlugin {
     public readonly Service: typeof Service;
     public readonly Characteristic: typeof Characteristic;
 
-    // this is used to track restored cached accessories
-    public readonly accessories: PlatformAccessory[] = [];
     private readonly publishedUUIDs: string[] = [];
 
     private readonly log: PrefixLogger;
@@ -58,20 +56,12 @@ export class AppleTVEnhancedPlatform implements DynamicPlatformPlugin {
             this.log.info('Starting device discovery ...');
             this.discoverDevices();
             setInterval(() => this.discoverDevices(), 60000);
+            setTimeout(() => this.warnNoDevices(), 150000);
         });
     }
 
-    /**
-   * This function is invoked when homebridge restores cached accessories from disk at startup.
-   * It should be used to setup event handlers for characteristics and update respective values.
-   */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public configureAccessory(accessory: PlatformAccessory): void {
-        this.log.info(`Loading accessory from cache: ${accessory.displayName}`);
-
-        // // add the restored accessory to the accessories cache so we can track if it has already been registered
-        this.accessories.push(accessory);
-    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+    public configureAccessory(accessory: PlatformAccessory): void {}
 
     /**
    * This is an example method showing how to register discovered accessories.
@@ -171,5 +161,12 @@ export class AppleTVEnhancedPlatform implements DynamicPlatformPlugin {
         }
 
         this.log.debug('Finished device discovery.');
+    }
+
+    private warnNoDevices(): void {
+        if (this.publishedUUIDs.length === 0) {
+            this.log.warn('The device discovery could not find any Apple TV devices until now. Are you sure that you have a compatible \
+Apple TV and the Apple TV is in the same subnet? (see https://github.com/maxileith/homebridge-appletv-enhanced#requirements)');
+        }
     }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,6 +23,7 @@ export interface ICommonConfig {
     configuredName?: string;
     activeIdentifier?: number;
     showAvadaKedavra?: number;
+    avadaKedavraName?: string;
 }
 
 export interface AppleTVEnhancedPlatformConfig extends Pick<PlatformConfig, '_bridge' | 'name' | 'platform'> {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,7 @@ export interface AppleTVEnhancedPlatformConfig extends Pick<PlatformConfig, '_br
     deviceStates?: NodePyATVDeviceState[];
     remoteKeysAsSwitch?: RocketRemoteKey[];
     avadaKedavraAppAmount?: number;
+    customInputURIs?: string[];
     discover?: {
         multicast?: boolean;
         unicast?: string[];
@@ -43,4 +44,9 @@ export interface AlternatePyATVDeviceOptions {
     id: string;
     airplayCredentials?: string;
     companionCredentials?: string;
+}
+
+export interface ICustomInput {
+    id: string;
+    name: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,5 @@ import type { RocketRemoteKey } from './enums.ts';
 
 export type TMediaConfigs = Partial<Record<NodePyATVMediaType, string>>;
 export type TDeviceStateConfigs = Partial<Record<NodePyATVDeviceState, string>>;
+export type TCustomInputConfigs = Record<string, string>;
 export type TRemoteKeysAsSwitchConfigs = Partial<Record<RocketRemoteKey, string>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,5 +3,4 @@ import type { RocketRemoteKey } from './enums.ts';
 
 export type TMediaConfigs = Partial<Record<NodePyATVMediaType, string>>;
 export type TDeviceStateConfigs = Partial<Record<NodePyATVDeviceState, string>>;
-export type TCustomInputConfigs = Record<string, string>;
 export type TRemoteKeysAsSwitchConfigs = Partial<Record<RocketRemoteKey, string>>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,14 @@ export function trimSpecialCharacters(value: string): string {
     return value;
 }
 
+export function trimToMaxLength(value: string, maxLength: number): string {
+    if (value.length <= maxLength) {
+        return value;
+    } else {
+        return value.substring(0, maxLength);
+    }
+}
+
 export function removeSpecialCharacters(str: string): string {
     return str.replace(/[^a-zA-Z0-9 ]/g, '').trim();
 }


### PR DESCRIPTION
## Added

* Ability to change Avada Kedavra input name #46
* Display a warning when there are no discovered Apple TVs after 150 seconds
* Add a warning when errors look like the access level is configured wrong in the home app #47 
* Custom URI based inputs #21 
* Active Inputs are now changed when the Apple TV reports that they have changed

## Changed

* **Apple TV is now exposed as an actual Apple TV, not a Set-Top-Box (requires you to repair your Apple TV in the Home app if you want to see the change)**
* Improved debug logging
* Improved error handling when validating credentials since this part is error prone
* upgrading dependencies

## Removed