### PR TITLE
Revert "pip: bump cryptography from 41.0.7 to 42.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2023.11.17
 cffi==1.16.0
 chacha20poly1305-reuseable==0.12.0
 charset-normalizer==3.3.2
-cryptography==42.0.0
+cryptography==41.0.7
 frozenlist==1.4.1
 idna==3.6
 ifaddr==0.2.0


### PR DESCRIPTION
Reverts maxileith/homebridge-appletv-enhanced#198