### PR TITLE
Tweaking 'Speakers & TV' access level error message to make it more clearer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,7 @@
 name: 🐞 Bug Report
 description: File a bug report.
+assignees:
+  - maxileith
 
 labels: ["bug"]
 
@@ -48,7 +50,7 @@ body:
     attributes:
       label: Logs
       description: |
-        Please provide relevant log output, from starting the plugin until the bug.
+        Please provide debug log output, from starting the plugin until the bug.
         Be sure to **remove any sensitive information** (MAC-Addresses and Airplay credentials).
         If you have a lengthy log message, please use the file upload functionality in the `Additional Context` section to supply log files.
       placeholder: Please paste logging output. Debug logging can be enabled in the plugin configuration.
@@ -67,42 +69,194 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: environment
+  - type: dropdown
+    id: environment_os
     attributes:
-      label: Environment
+      label: Operating System
       description: |
-        Describe your Environment when running the plugin.
-        It should include Operating System version, runtime version and the version of the software itself.
+        On which operating system is your homebridge running?
+      options:
+        - Linux
+        - Mac Os
+        - Windows
+      default: 0
+    validations:
+      required: true
 
-        The environment description might look like the following:
-          - **OS**: Raspberry Pi OS Bookworm 12
-          - **Docker**: false
-            - **Image Version**: 2023-11-28 (this is the minimum version, see [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))
-          - **Homebridge**: 1.7.0
-          - **Homebridge Config UI**: 4.54.2 (this is the minimum version, see [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))
-          - **Storage Path**: `/var/lib/homebridge`
-          - **Apple TV Enhanced**: v1.0.1 (always install the latest version before opening an issue)
-          - **Node**: 20.9.0 (output of `node -v`)
-          - **npm**: 10.1.0 (output of `npm -v`)
-          - **Python**: 3.11.2 (output of `python3 --version`)
-          - **pip**: 23.3.3 (output of `python3 -m pip --version`)
-          - **HDMI hops**: AV Receiver / HDMI Hub / Hue Sync Box ... (name all HDMI devices that are between the Apple TV and television)
-          - **HomePod as default speaker**: false
-      value: |
-        - OS: 
-        - Docker: 
-          - Image Version: 
-        - Homebridge: 
-        - Homebridge Config UI: 
-        - Storage Path: 
-        - Apple TV Enhanced: 
-        - Node: 
-        - npm: 
-        - Python: 
-        - pip: 
-        - HDMI hops: 
-        - HomePod as default speaker:
+  - type: dropdown
+    id: environment_os_bit
+    attributes:
+      label: "Operating System: Bits"
+      description: Is your OS 32 or 64 bit?
+      options:
+        - 32-bit
+        - 64-bit
+      default: 1
+    validations:
+      required: true
+
+  - type: input
+    id: environment_os_distribution
+    attributes:
+      label: "Operating System: Distribution"
+      description: |
+        Which distribution are you using?
+        Command to find out: `cat /etc/*-release | grep "^NAME="`
+      placeholder: Raspberry Pi OS
+    validations:
+      required: true
+
+  - type: input
+    id: environment_os_distribution_version
+    attributes:
+      label: "Operating System: Distribution Version"
+      description: |
+        Which version of your are you using?
+        Command to find out: `cat /etc/*-release | grep "^VERSION="`
+      placeholder: 12 (bookworm)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment_docker
+    attributes:
+      label: Docker
+      description: |
+        Are you hosting homebridge with docker?
+        Command to find out: `docker container list | grep homebridge`
+      options:
+        - "yes"
+        - "no"
+      default: 1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment_docker_image
+    attributes:
+      label: Docker Image
+      description: Which image are you using?
+      options:
+        - "homebridge/homebridge"
+        - "ozno/homebridge"
+
+  - type: input
+    id: environment_docker_image_version
+    attributes:
+      label: Docker Image Version
+      description: |
+        Which version of the image are you using? Please provide the exact image tag, not `latest`. (the minimum required version is specified in the [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))
+        Command to find out: `docker container list | grep homebridge`
+      placeholder: "2024-01-08"
+
+  - type: input
+    id: environment_homebridge_version
+    attributes:
+      label: Homebridge Version
+      description: Which version of homebridge are you using?
+      placeholder: "1.7.0"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_homebridge_config_ui_version
+    attributes:
+      label: Homebridge Config UI Version
+      description: Which version of homebridge ui are you using? (the minimum required version is specified in the [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))
+      placeholder: v4.54.2
+    validations:
+      required: true
+
+  - type: input
+    id: environment_storage_path
+    attributes:
+      label: Homebridge Storage Path
+      description: What is your homebridge storage path?
+      placeholder: /var/lib/homebridge
+    validations:
+      required: true
+
+  - type: input
+    id: environment_appletv_enhanced_version
+    attributes:
+      label: Homebridge Apple TV Enhanced Version
+      description: What is your Apple TV Enhanced Version? (always install the latest version before opening an issue)
+      placeholder: "1.2.4"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_node_version
+    attributes:
+      label: Node Version
+      description: |
+        What is your node version? (always install the latest version before opening an issue)
+        Command to find out: `node -v`
+      placeholder: v20.11.1
+    validations:
+      required: true
+
+  - type: input
+    id: environment_npm_version
+    attributes:
+      label: NPM Version
+      description: |
+        What is your npm version? (always install the latest version before opening an issue)
+        Command to find out: `npm -v`
+      placeholder: "10.2.4"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_python_version
+    attributes:
+      label: Python Version
+      description: |
+        What is your Python version?
+        Command to find out: `python3 --version`
+      placeholder: "3.11.6"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_pip_version
+    attributes:
+      label: Pip Version
+      description: |
+        What is your Pip version?
+        Command to find out: `python3 -m pip --version`
+      placeholder: "24.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_hdmi_hops
+    attributes:
+      label: HDMI Hops
+      description: Name all HDMI devices that are between the Apple TV and television
+      placeholder: "AV Receiver / HDMI Hub / Hue Sync Box ..."
+
+  - type: dropdown
+    id: environment_audio_output
+    attributes:
+      label: Audio Output
+      description: Are you using any audio output other than the HDMI port of the Apple TV itself.
+      options:
+        - "yes"
+        - "no"
+      default: 1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment_subnet
+    attributes:
+      label: Same Subnet
+      description: Is your Apple TV in the same subnet as your homebridge instance?
+      options:
+        - "yes"
+        - "no"
+      default: 0
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,7 @@
 name: 🚀 Feature Request
 description: Suggest an improvement or a new feature for this project.
+assignees:
+  - maxileith
 
 labels: ["enhancement"]
 

--- a/.github/ISSUE_TEMPLATE/support_request.yml
+++ b/.github/ISSUE_TEMPLATE/support_request.yml
@@ -1,5 +1,7 @@
 name: ❓ Support Request
 description: Get help when you encounter problems with Apple TV Enhanced. Or simply ask a question.
+assignees:
+  - maxileith
 
 labels: ["question"]
 
@@ -27,7 +29,7 @@ body:
     attributes:
       label: Logs
       description: |
-        Please provide relevant log output, from starting the plugin until the bug.
+        Please provide debug log output, from starting the plugin until the bug.
         Be sure to **remove any sensitive information** (MAC-Addresses and Airplay credentials).
         If you have a lengthy log message, please use the file upload functionality in the `Additional Context` section to supply log files.
       placeholder: Please paste logging output. Debug logging can be enabled in the plugin configuration.
@@ -46,42 +48,194 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: environment
+  - type: dropdown
+    id: environment_os
     attributes:
-      label: Environment
+      label: Operating System
       description: |
-        Describe your Environment when running the plugin.
-        It should include Operating System version, runtime version and the version of the software itself.
+        On which operating system is your homebridge running?
+      options:
+        - Linux
+        - Mac Os
+        - Windows
+      default: 0
+    validations:
+      required: true
 
-        The environment description might look like the following:
-          - **OS**: Raspberry Pi OS Bookworm 12
-          - **Docker**: false
-            - **Image Version**: 2023-11-28 (this is the minimum version, see [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))
-          - **Homebridge**: 1.7.0
-          - **Homebridge Config UI**: 4.54.2 (this is the minimum version, see [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))
-          - **Storage Path**: `/var/lib/homebridge`
-          - **Apple TV Enhanced**: v1.0.1 (always install the latest version before opening an issue)
-          - **Node**: 20.9.0 (output of `node -v`)
-          - **npm**: 10.1.0 (output of `npm -v`)
-          - **Python**: 3.11.2 (output of `python3 --version`)
-          - **pip**: 23.3.3 (output of `python3 -m pip --version`)
-          - **HDMI hops**: AV Receiver / HDMI Hub / Hue Sync Box ... (name all HDMI devices that are between the Apple TV and television)
-          - **HomePod as default speaker**: false
-      value: |
-        - OS: 
-        - Docker: 
-          - Image Version: 
-        - Homebridge: 
-        - Homebridge Config UI: 
-        - Storage Path: 
-        - Apple TV Enhanced: 
-        - Node: 
-        - npm: 
-        - Python: 
-        - pip: 
-        - HDMI hops: 
-        - HomePod as default speaker:
+  - type: dropdown
+    id: environment_os_bit
+    attributes:
+      label: "Operating System: Bits"
+      description: Is your OS 32 or 64 bit?
+      options:
+        - 32-bit
+        - 64-bit
+      default: 1
+    validations:
+      required: true
+
+  - type: input
+    id: environment_os_distribution
+    attributes:
+      label: "Operating System: Distribution"
+      description: |
+        Which distribution are you using?
+        Command to find out: `cat /etc/*-release | grep "^NAME="`
+      placeholder: Raspberry Pi OS
+    validations:
+      required: true
+
+  - type: input
+    id: environment_os_distribution_version
+    attributes:
+      label: "Operating System: Distribution Version"
+      description: |
+        Which version of your are you using?
+        Command to find out: `cat /etc/*-release | grep "^VERSION="`
+      placeholder: 12 (bookworm)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment_docker
+    attributes:
+      label: Docker
+      description: |
+        Are you hosting homebridge with docker?
+        Command to find out: `docker container list | grep homebridge`
+      options:
+        - "yes"
+        - "no"
+      default: 1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment_docker_image
+    attributes:
+      label: Docker Image
+      description: Which image are you using?
+      options:
+        - "homebridge/homebridge"
+        - "ozno/homebridge"
+
+  - type: input
+    id: environment_docker_image_version
+    attributes:
+      label: Docker Image Version
+      description: |
+        Which version of the image are you using? Please provide the exact image tag, not `latest`. (the minimum required version is specified in the [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))
+        Command to find out: `docker container list | grep homebridge`
+      placeholder: "2024-01-08"
+
+  - type: input
+    id: environment_homebridge_version
+    attributes:
+      label: Homebridge Version
+      description: Which version of homebridge are you using?
+      placeholder: "1.7.0"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_homebridge_config_ui_version
+    attributes:
+      label: Homebridge Config UI Version
+      description: Which version of homebridge ui are you using? (the minimum required version is specified in the [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))
+      placeholder: v4.54.2
+    validations:
+      required: true
+
+  - type: input
+    id: environment_storage_path
+    attributes:
+      label: Homebridge Storage Path
+      description: What is your homebridge storage path?
+      placeholder: /var/lib/homebridge
+    validations:
+      required: true
+
+  - type: input
+    id: environment_appletv_enhanced_version
+    attributes:
+      label: Homebridge Apple TV Enhanced Version
+      description: What is your Apple TV Enhanced Version? (always install the latest version before opening an issue)
+      placeholder: "1.2.4"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_node_version
+    attributes:
+      label: Node Version
+      description: |
+        What is your node version? (always install the latest version before opening an issue)
+        Command to find out: `node -v`
+      placeholder: v20.11.1
+    validations:
+      required: true
+
+  - type: input
+    id: environment_npm_version
+    attributes:
+      label: NPM Version
+      description: |
+        What is your npm version? (always install the latest version before opening an issue)
+        Command to find out: `npm -v`
+      placeholder: "10.2.4"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_python_version
+    attributes:
+      label: Python Version
+      description: |
+        What is your Python version?
+        Command to find out: `python3 --version`
+      placeholder: "3.11.6"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_pip_version
+    attributes:
+      label: Pip Version
+      description: |
+        What is your Pip version?
+        Command to find out: `python3 -m pip --version`
+      placeholder: "24.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: environment_hdmi_hops
+    attributes:
+      label: HDMI Hops
+      description: Name all HDMI devices that are between the Apple TV and television
+      placeholder: "AV Receiver / HDMI Hub / Hue Sync Box ..."
+
+  - type: dropdown
+    id: environment_audio_output
+    attributes:
+      label: Audio Output
+      description: Are you using any audio output other than the HDMI port of the Apple TV itself.
+      options:
+        - "yes"
+        - "no"
+      default: 1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment_subnet
+    attributes:
+      label: Same Subnet
+      description: Is your Apple TV in the same subnet as your homebridge instance?
+      options:
+        - "yes"
+        - "no"
+      default: 0
     validations:
       required: true
 

--- a/.github/issue_completeness_check/check.py
+++ b/.github/issue_completeness_check/check.py
@@ -1,0 +1,198 @@
+import sys
+import os
+import re
+import json
+import requests
+from packaging.version import parse as parse_version
+from github import Github, Auth
+
+GH_TOKEN = os.environ['GH_TOKEN']
+package_json = ""
+
+
+def check_logs(b: str) -> list[str]:
+    logs = b.split("### Logs", 1)[1].split('### Configuration')[0].strip()
+
+    output = []
+
+    if ("[I] Platform: Finished initializing platform: Apple TV Enhanced" not in logs):
+        output.append("Provide the **logs from the start** of the plugin, starting with `[I] Platform: Finished initializing platform: Apple TV Enhanced`")
+    
+    if ("[D]" not in logs):
+        output.append("Enable **debug logging** (loglevel 4)")
+    
+    return output
+
+
+def check_config(b: str) -> list[str]:
+    conf = b.split("### Configuration", 1)[1].split('### Operating System')[0].strip()
+
+    output = []
+
+    try:
+        json.loads(conf)
+    except json.decoder.JSONDecodeError:
+        output.append("The configuration is **no valid JSON**")
+    
+    return output
+
+
+def check_os(b: str) -> list[str]:
+    operating_system = b.split("### Operating System", 1)[1].split('### Operating System: Bits')[0].strip()
+
+    output = []
+
+    if (operating_system != "Linux"):
+        output.append("Only **Linux** is supported as an operating system (see [requirements](https://github.com/maxileith/homebridge-appletv-enhanced#requirements))")
+    
+    output += check_os_bits(b)
+
+    return output
+
+
+def check_os_bits(b: str) -> list[str]:
+    operating_system_bits = b.split("### Operating System: Bits", 1)[1].split('### Operating System: Distribution')[0].strip()
+
+    output = []
+
+    if (operating_system_bits != "64-bit"):
+        output.append("Only **64-bit** architectures are supported.")
+    
+    return output
+
+
+def check_docker(b: str) -> list[str]:
+    docker = b.split("### Docker", 1)[1].split('### Docker Image')[0].strip()
+
+    output = []
+
+    if (docker != "no"):
+        output += check_docker_image(b)
+        output += check_docker_image_version(b)
+    
+    return output
+
+
+def check_docker_image(b: str) -> list[str]:
+    image = b.split("### Docker Image", 1)[1].split('### Docker Image Version')[0].strip()
+
+    output = []
+
+    if (image != "homebridge/homebridge"):
+        output.append("Only the docker image **homebridge/homebridge** from [Docker Hub](https://hub.docker.com/r/homebridge/homebridge/) is supported.")
+    
+    return output
+
+
+def check_docker_image_version(b: str) -> list[str]:
+    version = b.split("### Docker Image Version", 1)[1].split('### Homebridge Version')[0].strip()
+
+    output = []
+
+    tag_regex = re.compile("^\d{4}-\d{2}-\d{2}$")
+
+    if (version == "latest"):
+        output.append("Please specify the **distinct image tag** (not `latest`), e.g. `2024-01-08`")
+    elif (not tag_regex.match(version)):
+        output.append("Please a tag that matches the pattern of the tagging strategy of homebridge/homebridge, e.g. `2024-01-08`")
+    else:
+        tags = get_all_docker_tags()
+        latest_digest = list(filter(lambda e: e['name'] == 'latest', tags))[0]['digest']
+        if (version not in map(lambda e: e['name'], tags)):
+            output.append(f"The **tag `{version}` does not exist** on homebridge/homebridge. Please provide an actual image tag.")
+        elif (latest_digest != list(filter(lambda e: e['name'] == version, tags))[0]['digest']):
+            latest_aliases = filter(lambda e: e['digest'] == latest_digest, tags)
+            latest_version = list(filter(lambda e: tag_regex.match(e['name']), latest_aliases))[0]['name']
+            output.append(f"The docker tag `{version}` is not the latest one. Please **update your docker container to image version `{latest_version}`**")
+
+    return output
+
+
+def check_homebridge_version(b: str) -> list[str]:
+    version = b.split("### Homebridge Version", 1)[1].split('### Homebridge Config UI Version')[0].strip()
+
+    if (version[0].lower() == "v"):
+        version = version[1:]
+
+    output = []
+
+    version_pattern = re.compile("^\d+\.\d+\.\d+$")
+
+    if (not version_pattern.match(version)):
+        output.append(f"The Homebridge version {version} does not match the expected version pattern of Homebridge.")
+    else:
+        min_homebridge_version = package_json['engines']['homebridge'][1:]
+
+        if (parse_version(version) < parse_version(min_homebridge_version)):
+            output.append(f"The current version of Apple TV Enhanced **requires Homebridge version `{min_homebridge_version}`**. You have installed version {version}.")
+
+    return output
+
+
+def check_homebridge_config_ui_version(b: str) -> list[str]:
+    version = b.split("### Homebridge Config UI Version", 1)[1].split('### Homebridge Storage Path')[0].strip()
+
+    if (version[0].lower() == "v"):
+        version = version[1:]
+
+    output = []
+
+    version_pattern = re.compile("^\d+\.\d+\.\d+$")
+
+    if (not version_pattern.match(version)):
+        output.append(f"The Homebridge Config UI version {version} does not match the expected version pattern of Homebridge Config UI.")
+    elif (parse_version(version) < parse_version('4.54.2')):
+        output.append(f"The current version of Apple TV Enhanced **requires Homebridge Config UI version `4.54.2`**. You have installed version {version}.")
+
+    return output
+
+
+def check_storage_path(b: str) -> list[str]:
+    path = b.split("### Homebridge Storage Path", 1)[1].split('### Homebridge Apple TV Enhanced Version')[0].strip()
+
+    path_pattern = re.compile("^(\/([a-zA-Z0-9_\-]|\\\\\s)+)+$")
+
+    output = []
+
+    if (not path_pattern.match(path)):
+        output.append(f"The path `{path}` is no valid absolute path. Please provide the homebridge storage **absolute** path.")
+
+    return output
+
+
+def get_all_docker_tags() -> list:
+    response = requests.get("https://hub.docker.com/v2/repositories/homebridge/homebridge/tags?page_size=10000000")
+    return response.json()['results']
+
+
+if __name__ == "__main__":
+    issue_id = int(sys.argv[1])
+
+    with open('package.json', 'r') as f:
+        package_json = json.loads(f.read())
+
+    auth = Auth.Token(GH_TOKEN)
+    g = Github(auth=auth)
+    r = g.get_repo("maxileith/homebridge-appletv-enhanced")
+    i = r.get_issue(issue_id)
+    b = i.body
+
+    todos = []
+
+    todos += check_logs(b)
+    todos += check_config(b)
+    todos += check_os(b)
+    todos += check_docker(b)
+    todos += check_homebridge_version(b)
+    todos += check_homebridge_config_ui_version(b)
+    todos += check_storage_path(b)
+
+    print("---- Comment ----")
+
+    md = "There are a few problems with your opened issue. Please fix them by editing the issue:\n\n"
+    for todo in todos:
+        md += f"- {todo}\n"
+
+    print(md)
+
+    g.close()

--- a/.github/issue_completeness_check/requirements.txt
+++ b/.github/issue_completeness_check/requirements.txt
@@ -1,0 +1,15 @@
+certifi==2024.2.2
+cffi==1.16.0
+charset-normalizer==3.3.2
+cryptography==42.0.3
+Deprecated==1.2.14
+idna==3.6
+packaging==23.2
+pycparser==2.21
+PyGithub==2.2.0
+PyJWT==2.8.0
+PyNaCl==1.5.0
+requests==2.31.0
+typing_extensions==4.9.0
+urllib3==2.2.1
+wrapt==1.16.0

--- a/.github/workflows/issue_completness_check.yml
+++ b/.github/workflows/issue_completness_check.yml
@@ -1,0 +1,53 @@
+name: Issue completeness check
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+
+jobs:
+  is_issue_complete:
+    name: Check if issue \#${{ github.event.issue.number }} is complete
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    if: contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.labels.*.name, 'question')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            package.json
+            .github/issue_completeness_check
+
+      - name: Use Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Print Python version
+        shell: bash
+        run: python3 --version
+
+      - name: Upgrade Pip
+        shell: bash
+        run: python3 -m pip install --upgrade pip
+
+      - name: Install dependencies
+        shell: bash
+        run: python3 -m pip install -r .github/issue_completeness_check/requirements.txt
+
+      - name: Print GitHub Actions context
+        shell: bash
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      - name: Run check
+        shell: bash
+        run: python3 .github/issue_completeness_check/check.py ${{ github.event.issue.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pip_req_comp_check.yml
+++ b/.github/workflows/pip_req_comp_check.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Upgrade Pip
         shell: bash
-        run: pip3 install --upgrade pip
+        run: python3 -m pip install --upgrade pip
 
       - name: Install dependencies
         shell: bash
-        run: pip3 install -r requirements.txt
+        run: python3 -m pip install -r requirements.txt

--- a/src/appleTVEnhancedAccessory.ts
+++ b/src/appleTVEnhancedAccessory.ts
@@ -1234,7 +1234,7 @@ media-src * \'self\'');
                     while (true) {
                         this.log.warn('The plugin is receiving errors that look like you have not set the access level of Speakers & TVs \
 in your home app to "Everybody" or "Anybody On the Same Network". Fix this and restart the plugin to continue initializing the Apple TV \
-device. Enable debug logging to see the original errors.');
+device. If this does not work, make sure to check the TV\'s HomeKit settings as well. Enable debug logging to see the original errors.');
                         await delay(300000);
                     }
                 }


### PR DESCRIPTION

Ran into an issue (refer to #264 ) with the 'Speakers & TV access level' error. Found out you gotta tweak both the Home app (Settings > Airplay and Homekit > Allow Access) and TV settings for it to work.

Made a pull request to fix the error message and include info on adjusting ATV settings. Hoping it clears things up for users who run in the same problem as I did. Take a look when you can, and feel free to tweak if needed.
Cheers! 