### PR TITLE
Allow name property for custom input URI

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -416,9 +416,14 @@
                 {
                     "key": "customInputURIs",
                     "type": "array",
-                    "items": {
-                        "key": "customInputURIs[]"
-                    }
+                    "items": [
+                        {
+                            "key": "customInputURIs[].uri"
+                        },
+                        {
+                            "key": "customInputURIs[].name"
+                        }
+                    ]
                 },
                 "avadaKedavraAppAmount",
                 "disableVolumeControlRemote",
@@ -502,7 +507,16 @@
                             "key": "deviceSpecificOverrides[].overrideCustomInputURIs",
                             "condition": {
                                 "functionBody": "return (new RegExp('^([A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2}$')).test(model.deviceSpecificOverrides[arrayIndices].mac);"
-                            }
+                            },
+                            "type": "array",
+                            "items": [
+                                {
+                                    "key": "customInputURIs[].uri"
+                                },
+                                {
+                                    "key": "customInputURIs[].name"
+                                }
+                            ]
                         },
                         {
                             "key": "deviceSpecificOverrides[].customInputURIs",

--- a/config.schema.json
+++ b/config.schema.json
@@ -108,10 +108,22 @@
                 "default": [],
                 "required": true,
                 "items": {
-                    "type": "string",
-                    "title": "URI",
-                    "pattern": "^(([^:\\/?#]+):)?(\\/\\/([^\\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$",
-                    "placeholder": "https://www.disneyplus.com/movies/rogue-one-a-star-wars-story/14CV6eSbygOA"
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "required": true,
+                            "type": "string",
+                            "title": "URI",
+                            "pattern": "^(([^:\\/?#]+):)?(\\/\\/([^\\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$",
+                            "placeholder": "https://www.disneyplus.com/movies/rogue-one-a-star-wars-story/14CV6eSbygOA"
+                        },
+                        "name": {
+                            "required": true,
+                            "type": "string",
+                            "title": "Name",
+                            "placeholder": "Rogue One: A Star Wars Story"
+                        }
+                    }
                 }
             },
             "disableVolumeControlRemote": {
@@ -342,10 +354,22 @@
                             "default": [],
                             "required": true,
                             "items": {
-                                "type": "string",
-                                "title": "URI",
-                                "pattern": "^(([^:\\/?#]+):)?(\\/\\/([^\\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$",
-                                "placeholder": "https://www.disneyplus.com/movies/rogue-one-a-star-wars-story/14CV6eSbygOA"
+                                "type": "object",
+                                "properties": {
+                                    "uri": {
+                                        "required": true,
+                                        "type": "string",
+                                        "title": "URI",
+                                        "pattern": "^(([^:\\/?#]+):)?(\\/\\/([^\\/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$",
+                                        "placeholder": "https://www.disneyplus.com/movies/rogue-one-a-star-wars-story/14CV6eSbygOA"
+                                    },
+                                    "name": {
+                                        "required": true,
+                                        "type": "string",
+                                        "title": "Name",
+                                        "placeholder": "Rogue One: A Star Wars Story"
+                                    }
+                                }
                             }
                         },
                         "overrideDisableVolumeControlRemote": {

--- a/src/appleTVEnhancedAccessory.ts
+++ b/src/appleTVEnhancedAccessory.ts
@@ -18,7 +18,7 @@ import {
     trimToMaxLength,
 } from './utils';
 import type {
-    AppleTVEnhancedPlatformConfig,
+    AppleTVEnhancedPlatformConfig, CustomInputURIConfiguration,
     DeviceConfigOverride,
     IAppConfig,
     IAppConfigs,
@@ -677,9 +677,12 @@ ${deviceStateDelay}ms is over): ${event.value}`);
         this.airPlayInputService!.updateCharacteristic(this.platform.Characteristic.ConfiguredName, configuredName);
     }
 
-    private createInputs(apps: NodePyATVApp[], customURIs: string[]): void {
+    private createInputs(apps: NodePyATVApp[], customURIs: (CustomInputURIConfiguration | string)[]): void {
         const appsAndCustomInputs: NodePyATVApp[] = [...customURIs.map((uri) => {
-            return { id: uri, name: uri };
+            if (typeof uri === 'string') {
+                return { id: uri, name: uri };
+            }
+            return { id: uri.uri, name: uri.name };
         }), ...apps];
 
         const appConfigs: IAppConfigs = this.getAppConfigs();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,6 +28,11 @@ export interface ICommonConfig {
     homeInputName?: string;
 }
 
+export interface CustomInputURIConfiguration {
+    uri: string;
+    name: string;
+}
+
 export interface DeviceConfigOverride {
     mac?: string;
     overrideMediaTypes?: boolean;
@@ -41,7 +46,7 @@ export interface DeviceConfigOverride {
     overrideAvadaKedavraAppAmount?: boolean;
     avadaKedavraAppAmount?: number;
     overrideCustomInputURIs?: boolean;
-    customInputURIs?: string[];
+    customInputURIs?: (CustomInputURIConfiguration | string)[];
     overrideDisableVolumeControlRemote?: boolean;
     disableVolumeControlRemote?: boolean;
     overrideSetTopBox?: boolean;
@@ -54,7 +59,7 @@ export interface AppleTVEnhancedPlatformConfig extends Pick<PlatformConfig, '_br
     deviceStateDelay?: number;
     remoteKeysAsSwitch?: RocketRemoteKey[];
     avadaKedavraAppAmount?: number;
-    customInputURIs?: string[];
+    customInputURIs?: (CustomInputURIConfiguration | string)[];
     disableVolumeControlRemote?: boolean;
     setTopBox?: boolean;
     deviceSpecificOverrides?: DeviceConfigOverride[];

--- a/user_storage/config.example.json
+++ b/user_storage/config.example.json
@@ -57,10 +57,22 @@
             ],
             "avadaKedavraAppAmount": 15,
             "customInputURIs": [
-                "https://www.disneyplus.com/movies/rogue-one-a-star-wars-story/14CV6eSbygOA",
-                "https://www.netflix.com/watch/81260280",
-                "https://tv.apple.com/show/silo/umc.cmc.3yksgc857px0k0rqe5zd4jice",
-                "vlc://https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8"
+                {
+                    "uri": "https://www.disneyplus.com/movies/rogue-one-a-star-wars-story/14CV6eSbygOA",
+                    "name": "Rogue One: A Star Wars Story"
+                },
+                {
+                    "uri": "https://www.netflix.com/watch/81260280",
+                    "name": "All Quiet on the Western Front"
+                },
+                {
+                    "uri": "https://tv.apple.com/show/silo/umc.cmc.3yksgc857px0k0rqe5zd4jice",
+                    "name": "Silo"
+                },
+                {
+                    "uri": "vlc://https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8",
+                    "name": "VLC Example"
+                }
             ],
             "disableVolumeControlRemote": false,
             "setTopBox": false,
@@ -85,7 +97,10 @@
                     "avadaKedavraAppAmount": 15,
                     "overrideCustomInputURIs": true,
                     "customInputURIs": [
-                        "https://www.disneyplus.com/de-de/movies/avatar-the-way-of-water/6hlsDJnhiU30"
+                        {
+                            "uri": "https://www.disneyplus.com/de-de/movies/avatar-the-way-of-water/6hlsDJnhiU30",
+                            "name": "Avatar: The Way of Water"
+                        }
                     ],
                     "overrideDisableVolumeControlRemote": true,
                     "disableVolumeControlRemote": true,


### PR DESCRIPTION
Thanks for this plugin, it has been working great. I have been using it to launch Youtube playlists on my TV in the morning, however it is becoming quite cumbersome to remember which is which.

This change adjusts the customInputURIs field to instead supply an object with an id and name. I am unsure if there is an option with homebridge to do a more elegant cutover, it seems this might remove existing custom uri properties.

If this does not align with the vision of this project, no drama.