### PR TITLE
v1.10.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-appletv-enhanced",
-    "version": "1.10.4",
+    "version": "1.10.5-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-appletv-enhanced",
-            "version": "1.10.4",
+            "version": "1.10.5-0",
             "cpu": [
                 "x32",
                 "x64",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
             "name": "homebridge-appletv-enhanced",
             "version": "1.10.4",
             "cpu": [
+                "x32",
                 "x64",
+                "arm",
                 "arm64"
             ],
             "funding": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homebridge-appletv-enhanced",
     "displayName": "Apple TV Enhanced",
-    "version": "1.10.4",
+    "version": "1.10.5-0",
     "description": "Plugin that exposes the Apple TV to HomeKit with much richer features than the vanilla Apple TV implementation of HomeKit.",
     "main": "dist/index.js",
     "author": "Maximilian Leith",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
         "darwin"
     ],
     "cpu": [
+        "x32",
         "x64",
+        "arm",
         "arm64"
     ],
     "engines": {


### PR DESCRIPTION
## Added

* Add 32-bit CPUs in the package.json. NPM will allow to install the plugin on 32-bit cpus. However, this does not mean that 32-bit systems are officially supported by the plugin.
 
## Changed

## Removed