### PR TITLE
v1.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "md5": "^2.3.0"
             },
             "devDependencies": {
-                "@eslint/js": "^9.23.0",
+                "@eslint/js": "^9.24.0",
                 "@stylistic/eslint-plugin-js": "^4.2.0",
                 "@stylistic/eslint-plugin-ts": "^4.2.0",
                 "@types/fs-extra": "^11.0.4",
@@ -48,7 +48,7 @@
                 "@types/node": "^22.14.0",
                 "@typescript-eslint/eslint-plugin": "^8.29.0",
                 "@typescript-eslint/parser": "^8.29.0",
-                "eslint": "^9.23.0",
+                "eslint": "^9.24.0",
                 "homebridge": "^1.9.0",
                 "homebridge-config-ui-x": "^4.72.0",
                 "nodemon": "^3.1.9",
@@ -286,9 +286,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-            "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+            "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -348,9 +348,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.23.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-            "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
+            "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3428,19 +3428,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.23.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-            "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.24.0.tgz",
+            "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.19.2",
+                "@eslint/config-array": "^0.20.0",
                 "@eslint/config-helpers": "^0.2.0",
                 "@eslint/core": "^0.12.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.23.0",
+                "@eslint/js": "9.24.0",
                 "@eslint/plugin-kit": "^0.2.7",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
                 "rimraf": "^6.0.1",
                 "standard-version": "^9.5.0",
                 "ts-node": "^10.9.2",
-                "typescript": "^5.8.2"
+                "typescript": "^5.8.3"
             },
             "engines": {
                 "homebridge": "^1.9.0 || ^2.0.0-beta.0",
@@ -8156,9 +8156,9 @@
             "dev": true
         },
         "node_modules/typescript": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "rimraf": "^6.0.1",
         "standard-version": "^9.5.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.2"
+        "typescript": "^5.8.3"
     },
     "dependencies": {
         "@sebbo2002/node-pyatv": "^8.1.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "url": "http://github.com/maxileith/homebridge-appletv-enhanced/issues"
     },
     "devDependencies": {
-        "@eslint/js": "^9.23.0",
+        "@eslint/js": "^9.24.0",
         "@stylistic/eslint-plugin-js": "^4.2.0",
         "@stylistic/eslint-plugin-ts": "^4.2.0",
         "@types/fs-extra": "^11.0.4",
@@ -75,7 +75,7 @@
         "@types/node": "^22.14.0",
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",
-        "eslint": "^9.23.0",
+        "eslint": "^9.24.0",
         "homebridge": "^1.9.0",
         "homebridge-config-ui-x": "^4.72.0",
         "nodemon": "^3.1.9",

--- a/src/PythonChecker.ts
+++ b/src/PythonChecker.ts
@@ -371,7 +371,7 @@ https://github.com/maxileith/homebridge-appletv-enhanced/issues/953');
         let response: AxiosResponse | undefined = undefined;
         try {
             response = await axios.get('https://raw.githubusercontent.com/postlund/pyatv/3fe8e36caf1977d2c7dced4767ada12c95a3e7c3/pyatv/\
-protocols/companion/api.py', { timeout: 1000 }) as AxiosResponse;
+protocols/companion/api.py', { timeout: 30000 }) as AxiosResponse;
             this.log.success('Successfully downloaded the fix');
             this.log.debug(`\n${response.data}`);
         } catch (e: unknown) {


### PR DESCRIPTION
## Added
 
## Changed

## Removed

* openssl legacy mode. The legacy mode cannot longer be supported as a required pyatv fix for TvOS 18.4 will only be provided with a pyatv version which requires OpenSSL 3. Refer to https://github.com/maxileith/homebridge-appletv-enhanced/issues/953