### PR TITLE
fix: defer Rocket Remote reconnection to prevent phantom TV wake-ups

### DIFF
--- a/src/appleTVEnhancedAccessory.ts
+++ b/src/appleTVEnhancedAccessory.ts
@@ -104,6 +104,7 @@ export class AppleTVEnhancedAccessory {
     private mediaConfigs: TMediaConfigs | undefined = undefined;
     private readonly mediaTypeServices: Partial<Record<NodePyATVMediaType, Service>> = {};
     private offline: boolean = false;
+    private pendingRemoteReconnect: boolean = false;
     private readonly pyatvCharacteristics: Partial<Record<PyATVCustomCharacteristicID, Characteristic>> = {};
     private readonly pyatvListenerHandlers: Partial<Record<PyATVCustomCharacteristicID, (e: Error | NodePyATVDeviceEvent) => void>> = {};
     private remoteKeyAsSwitchConfigs: TRemoteKeysAsSwitchConfigs | undefined = undefined;
@@ -783,8 +784,15 @@ from ${appConfigs[app.id].visibilityState} to ${value}.`);
         }).bind(this));
 
         this.rocketRemote.onClose((async (): Promise<void> => {
-            await delay(5000);
-            this.createRemote();
+            // Defer Rocket Remote reconnection until the Apple TV is awake.
+            // Reconnecting immediately spawns a new atvremote cli process whose
+            // Companion protocol handshake (_sessionStart, _touchStart,
+            // FetchAttentionState) wakes the Apple TV from sleep, which in turn
+            // triggers HDMI-CEC to turn on the TV.
+            // See: https://github.com/maxileith/homebridge-appletv-enhanced/issues/684
+            this.rocketRemote = undefined;
+            this.pendingRemoteReconnect = true;
+            this.log.warn('Rocket Remote disconnected. Deferring reconnect until device is awake.');
         }).bind(this));
     }
 
@@ -1172,6 +1180,14 @@ plugin after you have fixed the root cause. Enable debug logging to see the orig
         const STEPS: number = 500; // milliseconds
 
         if (state === this.platform.characteristic.Active.ACTIVE) {
+            // If Rocket Remote reconnection was deferred, reconnect now since
+            // the user is explicitly requesting to turn on the device.
+            if (this.pendingRemoteReconnect) {
+                this.pendingRemoteReconnect = false;
+                this.log.info('Reconnecting Rocket Remote for explicit turn-on request.');
+                this.createRemote();
+                await delay(2000); // Give atvremote time to connect
+            }
             this.rocketRemote?.turnOn();
             for (let i: number = STEPS; i <= WAIT_MAX_FOR_STATES * 1000; i += STEPS) {
                 const { mediaType, deviceState } = await this.device.getState();
@@ -1208,6 +1224,14 @@ plugin after you have fixed the root cause. Enable debug logging to see the orig
         this.log.info(`New Active State: ${event.value}`);
         if (value === this.platform.characteristic.Active.ACTIVE) {
             this.lastTurningOnEvent = Date.now();
+            // Reconnect Rocket Remote now that the device is confirmed awake.
+            // This avoids the Companion protocol handshake waking a sleeping
+            // Apple TV and triggering HDMI-CEC to turn on the TV.
+            if (this.pendingRemoteReconnect) {
+                this.pendingRemoteReconnect = false;
+                this.log.info('Device is awake. Reconnecting Rocket Remote now.');
+                this.createRemote();
+            }
         } else {
             this.log.debug('Reset all motion sensors.');
             // set all device state sensors to inactive


### PR DESCRIPTION
## Summary

When the Rocket Remote's `atvremote cli` process disconnects (due to network hiccups, Apple TV entering deep sleep, or TCP timeouts), the plugin immediately spawns a new `atvremote` process. The new process establishes a fresh Companion protocol session whose handshake (`_sessionStart`, `_touchStart`, `FetchAttentionState`) **wakes the Apple TV from sleep**. HDMI-CEC then propagates this to turn on the TV.

This causes TVs to turn on at random times — particularly overnight when WiFi interference causes periodic disconnections and the plugin keeps reconnecting.

## Root Cause

The reconnection flow:
1. Rocket Remote heartbeat (every 60s) detects connection loss → `atvremote cli` process exits
2. `onClose` handler waits 5s, then calls `createRemote()` which spawns a new `atvremote cli`
3. New process connects to Apple TV via Companion protocol
4. Protocol handshake (`_sessionStart` + `_touchStart` + `FetchAttentionState`) wakes the Apple TV
5. HDMI-CEC turns on the TV

## Fix

Instead of immediately reconnecting on disconnect, the Rocket Remote reconnection is **deferred** until the Apple TV is confirmed awake:

- On disconnect: set `pendingRemoteReconnect = true` and nullify the remote reference
- On `handleActiveUpdate` receiving `ACTIVE`: reconnect the Rocket Remote
- On explicit `handleActiveSet(ACTIVE)` (user turns on via HomeKit): reconnect immediately to fulfill the request

This ensures the Companion protocol session is only established when the Apple TV is already awake, preventing phantom wake-ups.

## Changes

- Added `pendingRemoteReconnect` property to `AppleTVEnhancedAccessory`
- Modified `createRemote()` `onClose` handler to defer instead of immediate reconnect
- Modified `handleActiveUpdate()` to reconnect when device wakes up
- Modified `handleActiveSet()` to reconnect on explicit turn-on request

## Testing

- Deployed patched plugin on Homebridge v1.11.2, Node v24.13.1
- Plugin initializes and connects normally
- Rocket Remote connects successfully on startup
- When Apple TV is off, the remote is not reconnected on disconnect (verified via logs)

Fixes #684